### PR TITLE
Fix for players with no data

### DIFF
--- a/update.py
+++ b/update.py
@@ -234,6 +234,7 @@ for (id, crown) in hof.ranking:
 playerCache = dict()
 
 for uuid, player in players.items():
+    # skip players with no data
     if 'last' not in player:
         continue
     playerCache[uuid] = {

--- a/update.py
+++ b/update.py
@@ -234,6 +234,8 @@ for (id, crown) in hof.ranking:
 playerCache = dict()
 
 for uuid, player in players.items():
+    if 'last' not in player:
+        continue
     playerCache[uuid] = {
         'name': player['name'],
         'last': player['last'],


### PR DESCRIPTION
If a player exists in the MC world data, but doesn't have playerdata, they will cause an error in the script, and the website will stop working.

This resolves that by checking for players with no data, and skipping them.