### PR TITLE
Using getJson instead of ajax call

### DIFF
--- a/js/mcstats-loader.js
+++ b/js/mcstats-loader.js
@@ -16,7 +16,7 @@ loadJson = function(url, successFunc, compressed = false) {
         req.send();
     } else {
         // simple AJAX request
-        $.ajax({url: url, success: successFunc});
+        $.getJSON({url: url, success: successFunc});
     }
 };
 


### PR DESCRIPTION
By using getJSON function, this will pass an object to the success function instead of passing in a simple string (that can then rise an error)