### PR TITLE
Implement quick fix for issue #94 (newlines in MOTD)

### DIFF
--- a/js/dev/mcstats-start.js
+++ b/js/dev/mcstats-start.js
@@ -13,7 +13,7 @@ loader.addRequest('data/summary.json.gz', function(summary) {
 
     // fill server info
     serverName = JSON.parse('"' + mcstats.info.serverName + '"');
-    serverNameNoFmt = mcstats.removeColorCodes(serverName);
+    serverNameNoFmt = mcstats.removeColorCodes(serverName).replace('<br>', ' / ');
 
     document.title = `${serverNameNoFmt} \u2013 Stats`;
     document.getElementById('server-name').innerHTML = mcstats.formatColorCode(serverName);

--- a/update.py
+++ b/update.py
@@ -129,7 +129,9 @@ if not args.server_name:
         for line in f:
             m = p.match(line)
             if m:
-                args.server_name = javaproperties.unescape(m.group(1))
+                args.server_name = javaproperties.unescape(
+                                       m.group(1)
+                                   ).replace('\n', '<br>')
                 break
 
 # try and load usercache


### PR DESCRIPTION
It's not pretty, but it seems to work. Basically just replaces `\n` with `<br>` on the backend. The newline renders properly on the frontend, and `document.title` replaces it with ` / ` so both lines are displayed. Doesn't seem to affect color rendering.