### PR TITLE
Option for including ops.json in the UUID to name lookup

### DIFF
--- a/mcstats/config.py
+++ b/mcstats/config.py
@@ -21,6 +21,7 @@ defaultConfig = {
         "updateInactive": False,     # also update profile for inactive players
         "inactiveDays": 7,           # number of offline days before a player is considered inactive
         "minPlaytime": 60,           # number of minutes a player must have played before entering stats
+        "lookupUsingOPs": True,      # Include ops.json in the UUID to name lookup
         "excludeBanned": True,       # whether or not to exclude banned players
         "excludeOps": False,         # whether or not to exclude ops
         "excludeUUIDs": []           # list of UUIDs to exclude

--- a/update.py
+++ b/update.py
@@ -178,6 +178,18 @@ for (path, _) in sources:
     except:
         handle_error('Cannot open ' + usercacheFile + ' for offline player lookup')
 
+# try and load OPs
+oplist = dict()
+if config.players.lookupUsingOPs:
+    for (path, _) in sources:
+        opsFile = os.path.join(path, 'ops.json')
+        try:
+            with open(opsFile) as f:
+                for entry in json.load(f):
+                    oplist[entry['uuid']] = entry['name']
+        except:
+            handle_error('Cannot open ' + opsFile + ' for offline (op player) lookup')
+
 # exclude players
 excludePlayers = set()
 
@@ -378,6 +390,10 @@ for uuid, player in players.items():
         if (not 'name' in player) and (uuid in usercache):
             # no profile available, but the UUID is in the usercache
             player['name'] = usercache[uuid]
+
+        if (not 'name' in player) and (uuid in oplist):
+            # no profile available, but the UUID is in the OP list
+            player['name'] = oplist[uuid]
 
         if (not 'name' in player):
             # there is no way to find the name of this player


### PR DESCRIPTION
No extra libraries used and barely any extra overhead in adding this.  On my server, the usercache.json was missing me and the other OPs on my server.  It seems like spigot (and maybe vanilla, i have not tested it) may have just taken the UUID and Player Name from this ops.json file.  In order to avoid missing players in the statistics, I added data from ops.json for the UUID to Name lookup.