### PR TITLE
Option for including Multiverse Inventories & Factions plugin data in…

### DIFF
--- a/mcstats/config.py
+++ b/mcstats/config.py
@@ -21,6 +21,9 @@ defaultConfig = {
         "updateInactive": False,     # also update profile for inactive players
         "inactiveDays": 7,           # number of offline days before a player is considered inactive
         "minPlaytime": 60,           # number of minutes a player must have played before entering stats
+        "pluginFolder": "plugins",   # For the next two options, a valid plugin folder name (ignore if vanilla)
+        "lookupUsingMVI": True,      # Include Multiverse Inventories plugin in the UUID to name lookup
+        "lookupUsingFaction": True,  # Include Factions plugin in the UUID to name lookup
         "excludeBanned": True,       # whether or not to exclude banned players
         "excludeOps": False,         # whether or not to exclude ops
         "excludeUUIDs": []           # list of UUIDs to exclude

--- a/update.py
+++ b/update.py
@@ -6,6 +6,7 @@ import gzip
 import json
 import math
 import os
+import pathlib
 import re
 import shutil
 import sys
@@ -177,6 +178,41 @@ for (path, _) in sources:
                 usercache[entry['uuid']] = entry['name']
     except:
         handle_error('Cannot open ' + usercacheFile + ' for offline player lookup')
+
+# try and load from MV Inventories
+mvinvlist = dict()
+if config.players.lookupUsingMVI:
+    for (path, _) in sources:
+        mvpath = config.players.pluginFolder + '/Multiverse-Inventories/players'
+        mvpath = os.path.join(path, mvpath)  # 'plugins/Multiverse-Inventories/players'
+        try:
+            for filenamemvpath in pathlib.Path(mvpath).iterdir():
+                if filenamemvpath.is_file():
+                    filenamemvSTR = os.path.join(filenamemvpath)
+                    try:
+                        with open(filenamemvpath) as f:
+                            string = f.read()
+                            filename = os.path.basename(filenamemvpath)
+                            filenameuuid = os.path.splitext(filename)[0]
+                            entry = json.loads(string, object_hook=lambda d: types.SimpleNamespace(**d))
+                            mvinvlist[filenameuuid] = entry.playerData.lastKnownName
+                    except:
+                        handle_error('Cannot open ' + filenamemvSTR + ' for offline (multiverse inv) player lookup')
+        except:
+            handle_error('Cannot open ' + mvpath + ' for offline (multiverse inventory) player lookup')
+
+# try and load from Factions
+factionlist = dict()
+if config.players.lookupUsingFaction:
+    for (path, _) in sources:
+        factionpath = config.players.pluginFolder + '/MassiveCore/idnamecache.json'
+        factionpath = os.path.join(path, factionpath)  # 'plugins/MassiveCore/idnamecache.json'
+        try:
+            with open(factionpath) as f:
+                for entry in json.load(f):
+                    factionlist[entry['id']] = entry['name']
+        except:
+            handle_error('Cannot open ' + factionpath + ' for offline (factions cache) player lookup')
 
 # exclude players
 excludePlayers = set()
@@ -378,6 +414,14 @@ for uuid, player in players.items():
         if (not 'name' in player) and (uuid in usercache):
             # no profile available, but the UUID is in the usercache
             player['name'] = usercache[uuid]
+
+        if (not 'name' in player) and (uuid in mvinvlist):
+            # no profile available, but the UUID is in the multiverse inventory list
+            player['name'] = mvinvlist[uuid]
+
+        if (not 'name' in player) and (uuid in factionlist):
+            # no profile available, but the UUID is in the faction list
+            player['name'] = factionlist[uuid]
 
         if (not 'name' in player):
             # there is no way to find the name of this player


### PR DESCRIPTION
… the UUID to name lookup.  

Using Multiverse Inventories data files to supplement the usercache's lookup table.  This required an additional library: pathlib.  

Using Factions data files to supplement the usercache's lookup table.  This did not require any additional libraries.  