### PR TITLE
Remove StatDiffReader for 'Nether Wart' and 'Sugar Cane' harvesting stats

### DIFF
--- a/mcstats/stats/collect_shroom.py
+++ b/mcstats/stats/collect_shroom.py
@@ -6,7 +6,6 @@ mcstats.registry.append(
         {
             'unit': 'int',
         },
-        # subtract placed from mined
         mcstats.StatSumReader([
             mcstats.StatReader(['minecraft:picked_up','minecraft:red_mushroom']),
             mcstats.StatReader(['minecraft:picked_up','minecraft:brown_mushroom']),

--- a/mcstats/stats/harvest_nether_wart.py
+++ b/mcstats/stats/harvest_nether_wart.py
@@ -6,8 +6,5 @@ mcstats.registry.append(
         {
             'unit': 'int',
         },
-        mcstats.StatDiffReader(
-            mcstats.StatReader(['minecraft:picked_up','minecraft:nether_wart']),
-            mcstats.StatReader(['minecraft:used','minecraft:nether_wart'])
-        )
+        mcstats.StatReader(['minecraft:picked_up','minecraft:nether_wart']),
     ))

--- a/mcstats/stats/harvest_sugar.py
+++ b/mcstats/stats/harvest_sugar.py
@@ -6,8 +6,5 @@ mcstats.registry.append(
         {
             'unit': 'int',
         },
-        mcstats.StatDiffReader(
-            mcstats.StatReader(['minecraft:picked_up','minecraft:sugar_cane']),
-            mcstats.StatReader(['minecraft:used','minecraft:sugar_cane'])
-        )
+        mcstats.StatReader(['minecraft:picked_up','minecraft:sugar_cane']),
     ))


### PR DESCRIPTION
Fixes issue https://github.com/pdinklag/MinecraftStats/issues/161 where stats for these items could end up in the negative if you used more of these items than you harvested yourself, as commonly seen on Survival servers. This is a similar fix to https://github.com/pdinklag/MinecraftStats/issues/153, and the correct behaviour has always existed in `harvest_bamboo.py`, so this change simply replicates it for harvesting Nether Warts and Sugar Cane.

Also removes an erroneous comment in `collect_shroom.py` left over from changes in issue https://github.com/pdinklag/MinecraftStats/issues/153 / commit https://github.com/pdinklag/MinecraftStats/commit/5025520d496c91093dad3e53f98bf291d4044343