### PR TITLE
fix(#175): display ended event winners

### DIFF
--- a/update.py
+++ b/update.py
@@ -486,7 +486,10 @@ for event in eventStats:
         continue
 
     # sort ranking
-    event.ranking = sorted(event.ranking, key = lambda i: i['value'], reverse=True)
+    try:
+        event.ranking = sorted(event.ranking, key = lambda i: i['value'], reverse=True)
+    except Exception as e:
+        event.sort()
 
     # create summary
     esummary = {
@@ -497,10 +500,15 @@ for event in eventStats:
         'active':    event.isRunning(),
     }
 
+
     if(len(event.ranking) > 0):
         best = event.ranking[0]
-        esummary['best'] = {'uuid': best['uuid'], 'value': best['value']}
-        summaryPlayerIds.add(best['uuid'])
+        try:
+            esummary['best'] = {'uuid': best['uuid'], 'value': best['value']}
+            summaryPlayerIds.add(best['uuid'])
+        except Exception as e:
+            esummary['best'] = {'uuid': best.id, 'value': best.value}
+            summaryPlayerIds.add(best.id)
 
     summaryEvents[event.name] = esummary
 

--- a/update.py
+++ b/update.py
@@ -267,6 +267,7 @@ for e in events:
         with open(eventDataFile) as f:
             eventData = json.load(f)
             eventStat.initialRanking = eventData['initialRanking']
+            eventStat.ranking = eventData['ranking']
     elif eventStat.hasStarted():
         print('event \"' + e.name + '\" has already started, but no initial ranking is available')
 
@@ -485,7 +486,7 @@ for event in eventStats:
         continue
 
     # sort ranking
-    event.sort()
+    event.ranking = sorted(event.ranking, key = lambda i: i['value'], reverse=True)
 
     # create summary
     esummary = {
@@ -498,8 +499,8 @@ for event in eventStats:
 
     if(len(event.ranking) > 0):
         best = event.ranking[0]
-        esummary['best'] = {'uuid': best.id, 'value': best.value}
-        summaryPlayerIds.add(best.id)
+        esummary['best'] = {'uuid': best['uuid'], 'value': best['value']}
+        summaryPlayerIds.add(best['uuid'])
 
     summaryEvents[event.name] = esummary
 


### PR DESCRIPTION
 This PR fixes the sorting error that `event.sort()` was trying to sort `ranking`, which is an array of <Dict, Dict>

Tested and deployed on my branch.