### PR TITLE
Excluding players with specific prefix

### DIFF
--- a/mcstats/config.py
+++ b/mcstats/config.py
@@ -1,5 +1,5 @@
 defaultConfig = {
-    "configVersion": 1,
+    "configVersion": 2,
     "database": "data",              # where the database is written
     "server": {
         "sources": [
@@ -21,9 +21,13 @@ defaultConfig = {
         "updateInactive": False,     # also update profile for inactive players
         "inactiveDays": 7,           # number of offline days before a player is considered inactive
         "minPlaytime": 60,           # number of minutes a player must have played before entering stats
-        "excludeBanned": True,       # whether or not to exclude banned players
-        "excludeOps": False,         # whether or not to exclude ops
-        "excludeUUIDs": []           # list of UUIDs to exclude
+    },
+    "rules": {
+        "excludePlayer": {
+            "banned": True,          # whether or not to exclude banned players
+            "op": False,             # whether or not to exclude ops
+            "UUID": []               # list of UUIDs to exclude
+        }
     },
     "crown": {
         "gold": 4,                   # crown score worth of a gold medal     

--- a/mcstats/config.py
+++ b/mcstats/config.py
@@ -24,6 +24,11 @@ defaultConfig = {
     },
     "rules": {
         "excludePlayer": {
+            "prefix": {              # exclude players which name starts with the following string if enabled
+                "enable": False,     # whether or not to enable this function
+                "prefix": "",        # prefix
+                "ignoreCase": False  # whether or not to ignore case sensitivity during matching
+            },
             "banned": True,          # whether or not to exclude banned players
             "op": False,             # whether or not to exclude ops
             "UUID": []               # list of UUIDs to exclude

--- a/update.py
+++ b/update.py
@@ -206,6 +206,24 @@ if config.rules.excludePlayer.op:
         except:
             handle_error('Cannot open ' + opsFile + ' for op exclusion')
 
+# exclude specific prefix(e.g. bot_ refers to fake player)
+if config.rules.excludePlayer.prefix.enable:
+    for (path, _) in sources:
+        usercacheFile = os.path.join(path, 'usercache.json')
+        try:
+            with open(usercacheFile) as f:
+                for entry in json.load(f):
+                    m = False
+                    if config.rules.excludePlayer.prefix.ignoreCase:
+                        pattern = re.compile('^' + config.rules.excludePlayer.prefix.prefix, re.IGNORECASE)
+                        m = bool(pattern.match(entry['name']))
+                    else:
+                        m = bool(entry['name'].startswith(config.rules.excludePlayer.prefix.prefix))
+                    if m:
+                        excludePlayers.add(entry['uuid'])
+        except:
+            handle_error('Cannot open ' + usercacheFile + ' for specific prefix exclusion')
+
 # initialize database
 if not os.path.isdir(config.database):
     os.mkdir(config.database)

--- a/update.py
+++ b/update.py
@@ -181,11 +181,11 @@ for (path, _) in sources:
 # exclude players
 excludePlayers = set()
 
-for uuid in config.players.excludeUUIDs:
+for uuid in config.rules.excludePlayer.UUID:
     excludePlayers.add(uuid)
 
 # exclude banned players
-if config.players.excludeBanned:
+if config.rules.excludePlayer.banned:
     for (path, _) in sources:
         bannedPlayersFile = os.path.join(path, 'banned-players.json')
         try:
@@ -196,7 +196,7 @@ if config.players.excludeBanned:
             handle_error('Cannot open ' + bannedPlayersFile + ' for banned player exclusion')
 
 # exclude ops
-if config.players.excludeOps:
+if config.rules.excludePlayer.op:
     for (path, _) in sources:
         opsFile = os.path.join(path, 'ops.json')
         try:

--- a/update.py
+++ b/update.py
@@ -55,6 +55,11 @@ else:
 
 config = RecursiveNamespace(**configJson)
 
+# check config version
+if config.configVersion != 2:
+    handle_error('Incorrect config version. Maybe you need to check your config file or update it manually')
+    exit(127)
+
 # get sources
 sources = []
 if hasattr(config.server, 'path') and config.server.path:


### PR DESCRIPTION
In some server, fake players are used widely. Usually they have a same prefix ( like "bot_", if correctly configured in carpet mod ). Most fake players have abnormal statistics. For example, the longest online time, mostly much longer than any other player. 