### PR TITLE
Event winner display fix

### DIFF
--- a/www/js/dev/mcstats-eventlist.js
+++ b/www/js/dev/mcstats-eventlist.js
@@ -1,87 +1,99 @@
-mcstats.showEventList = function() {
-    var viewHTML = '';
+mcstats.showEventList = function () {
+  var viewHTML = "";
 
-    var generateList = function(keysByDate){
-        var tbody = '';
-        keysByDate.forEach(function(id){
-            var e = mcstats.events[id];
-            var award = mcstats.awards[e.link];
+  var generateList = function (keysByDate) {
+    var tbody = "";
+    var promises = keysByDate.map(function (id) {
+      return new Promise(function (resolve) {
+        loadJson("data/events/" + id + ".json", function (eventData) {
+          var e = mcstats.events[id];
+          var award = mcstats.awards[e.link];
 
-            var eventWidget = mcstats.eventWidget(id);
-            if(e.active) {
-                eventWidget += `<span class="text-success ms-2">[${mcstats.localize('page.eventList.live')}]</span>`;
-            }
+          var eventWidget = mcstats.eventWidget(id);
 
-            var holder, info;
-            if(e.best) {
-                holder = mcstats.playerWidget(e.best.uuid);
-                info = award.desc + ': ' + mcstats.formatValue(e.best.value, award.unit, true);
-            } else {
-                holder = mcstats.playerWidget(false);
-                info = `<span class="text-muted">(${award.desc})</span>`;
-            }
+          if (e.active) {
+            eventWidget += `<span class="text-success ms-2">[${mcstats.localize("page.eventList.live")}]</span>`;
+          }
 
-            var eventTime;
-            if(e.active) {
-                eventTime = `${mcstats.localize('page.eventList.ongoingSince')} ${formatDate(e.startTime)}! <br /> ${mcstats.localize('page.eventList.endsAt')} ${formatDate(e.stopTime)}.`;
-            } else {
-                eventTime = `${formatDate(e.startTime)} - ${formatDate(e.stopTime)}`;
-            }
+          if (eventData.ranking.length > 0) {
+            var holder = mcstats.playerWidget(eventData.ranking[0].uuid);
+            var info = `<span class="text-muted">(${award.desc})</span>`;
+          } else {
+            var holder = mcstats.playerWidget(false);
+            var info = `<span class="text-muted">${award.desc})</span>`;
+          }
 
-            var eventStartTime = formatTime(e.startTime);
-            var live = e.active
-                ? `<span class="ps-2 text-success">[${mcstats.localize('page.eventList.live')}]</span>`
-                : `<span class="ps-2 text-danger">[${mcstats.localize('page.eventList.finished')}]</span>`;
+          var eventTime;
+          if (e.active) {
+            eventTime = `${mcstats.localize("page.eventList.ongoingSince")} ${formatDate(e.startTime)}! <br /> ${mcstats.localize("page.eventList.endsAt")} ${formatDate(e.stopTime)}.`;
+          } else {
+            eventTime = `${formatDate(e.startTime)} - ${formatDate(e.stopTime)}`;
+          }
 
-            tbody += `
-                <div class="row">
-                <div class="col-sm">
-                    <div class="container p-1 mb-3 mcstats-entry">
-                        <div class="p-1 mb-1 round-box text-center align-middle">
-                            <div class="h4">
-                                <img class="img-pixelated img-textsize align-baseline" src="img/award-icons/${e.link}.png" alt="${id}" title="${e.title}"/>
-                                <a href="#event:${id}">${e.title}</a>
-                                ${live}
-                            </div>
-                            <div class="text-muted">
-                                ${eventTime}
-                            </div>
+          var eventStartTime = formatTime(e.startTime);
+          var live = e.active
+            ? `<span class="ps-2 text-success">[${mcstats.localize("page.eventList.live")}]</span>`
+            : `<span class="ps-2 text-danger">[${mcstats.localize("page.eventList.finished")}]</span>`;
+
+          tbody = `
+              <div class="row">
+              <div class="col-sm">
+                  <div class="container p-1 mb-3 mcstats-entry">
+                    <div class="p-1 mb-1 round-box text-center align-middle">
+                      <div class="h4">
+                        <img class="img-pixelated img-textsize align-baseline" src="img/award-icons/${e.link}.png" alt="${id}" title="${e.title}"/>
+                          <a href="#event:${id}">${e.title}</a>
+                          ${live}
                         </div>
-                        <div class="p-1 round-box text-center">
-                            <span class="rank-1">${mcstats.localize(e.active ? 'page.eventList.leading' : 'page.eventList.winner')}:</span>
-                            ${holder}
-                            <br/>
-                            ${info}
+                        <div class="text-muted">
+                            ${eventTime}
                         </div>
-                    </div>
-                </div>
-                </div>
-            `;
+                      </div>
+                      <div class="p-1 round-box text-center">
+                          <span class="rank-1">${mcstats.localize(e.active? "page.eventList.leading": "page.eventList.winner")}:</span>
+                          ${holder}
+                          <br/>
+                          ${info}
+                      </div>
+                  </div>
+              </div>
+              </div>
+          `;
+          resolve(tbody);
         });
-        return tbody;
-    };
+      });
+    });
 
-    mcstats.viewContent.innerHTML = '';
+    return Promise.all(promises).then(function (html) {
+      return html.join("");
+    });
+  };
 
-    // ongoing events
-    if(mcstats.liveEventKeysByDate.length > 0) {
-        mcstats.viewContent.innerHTML += `
-            <div class="text-center mb-2">
-                <div class="h5 text-shadow">${mcstats.localize('page.eventList.ongoingEvents')}</div>
-            </div>
-            ${generateList(mcstats.liveEventKeysByDate)}
-        `;
-    }
-    
-    // finished events
-    if(mcstats.finishedEventKeysByDate.length > 0) {
-        mcstats.viewContent.innerHTML += `
-            <div class="text-center mb-2 mt-4">
-                <div class="h5 text-shadow">${mcstats.localize('page.eventList.finishedEvents')}</div>
-            </div>
-            ${generateList(mcstats.finishedEventKeysByDate)}
-        `;
-    }
-    
-    mcstats.showView(mcstats.localize('page.eventList.title'), false, false, false);
+  mcstats.viewContent.innerHTML = "";
+
+  // ongoing events
+  if (mcstats.liveEventKeysByDate.length > 0) {
+    generateList(mcstats.liveEventKeysByDate).then(function (ongoingEvents) {
+      mcstats.viewContent.innerHTML += `
+          <div class="text-center mb-2">
+              <div class="h5 text-shadow">${mcstats.localize("page.eventList.ongoingEvents")}</div>
+          </div>
+              ${ongoingEvents}
+      `;
+    });
+  }
+
+  // finished events
+  if (mcstats.finishedEventKeysByDate.length > 0) {
+    generateList(mcstats.finishedEventKeysByDate).then(function (finishedEvents) {
+      mcstats.viewContent.innerHTML += `
+          <div class="text-center mb-2 mt-4">
+              <div class="h5 text-shadow">${mcstats.localize("page.eventList.finishedEvents")}</div>
+          </div>
+              ${finishedEvents}
+          `;
+    });
+  }
+
+  mcstats.showView(mcstats.localize("page.eventList.title"), false, false, false);
 };


### PR DESCRIPTION
Wasn't sure if this was being worked on at all but I know in the past there's been a couple of issues relating to this, #175 #189 etc.

Since the switch to java, event winners haven't displayed properly in either ongoing or ended events. This fix simply reads each event json and gets the first value in the `ranking` array since from what I can tell they're processed to be in order. 

Since this is simply a frontend change, should work for either plugin or cli. Working implementation can be found [here](https://stats.terrashift.net/#events) so you can verify the fix